### PR TITLE
Fix directory context. Resolves #4

### DIFF
--- a/k0sdown
+++ b/k0sdown
@@ -1,17 +1,31 @@
 #!/bin/bash
 
-k0sdir="$(dirname $(readlink ${BASH_SOURCE[0]}))"
+# setup variables for context checking
+execDir=${BASH_SOURCE[0]}
+execDirCheck=$(readlink $execDir)
+
+# check the context and set appropriately
+if [ -z $execDirCheck ]; then
+  k0sdir=$(pwd)
+else
+  k0sdir=$(dirname $execDirCheck)
+fi
+
+# this needs to be here since $k0sdir isn't established until just prior
 nginxdir=$k0sdir/nginx
 
+# loop through all running containers and kill ones that start with k0s-
 echo "shutting down all nodes..."
 for n in $(docker ps | awk '/k0s-/ { print $1 }')
 do
   docker stop $n &> /dev/null
 done
 
+# recovering disk space
 echo "cleaning up after myself..."
 echo "   system space recovered: $(docker system prune -f | awk '/reclaimed space/ { print $4 }')"
 echo "   volume space recovered: $(docker volume prune -f | awk '/reclaimed space/ { print $4 }')"
 
+# removing nginx config used on load balancer
 echo "removing nginx config file..."
 rm $nginxdir/default.conf

--- a/k0sup
+++ b/k0sup
@@ -1,7 +1,18 @@
 #!/bin/bash
 
+# determine absolute path of the executable
+execDir=${BASH_SOURCE[0]}
+execDirCheck=$(readlink $execDir)
+
+# check the context and set appropriately
+if [ -z $execDirCheck ]; then
+  k0sdir=$(pwd)
+else
+  k0sdir=$(dirname $execDirCheck)
+fi
+
+# paths setup and discovery
 workernodes=$1
-k0sdir="$(dirname $(readlink ${BASH_SOURCE[0]}))"
 nginxdir=$k0sdir/nginx
 nginxconf=$nginxdir/default.conf
 node=1


### PR DESCRIPTION
This resolves the issue where users executing the script directly in the cloned folder could not successfully launch a cluster due to the path being incorrectly detected and set.﻿
